### PR TITLE
Add publisher class and refactor

### DIFF
--- a/src/main/kotlin/de/smartsquare/starter/mqtt/MqttAutoConfiguration.kt
+++ b/src/main/kotlin/de/smartsquare/starter/mqtt/MqttAutoConfiguration.kt
@@ -66,12 +66,29 @@ class MqttAutoConfiguration {
     fun jackson(): ObjectMapper = jacksonObjectMapper().findAndRegisterModules()
 
     @Bean
-    fun adapter(
-        collector: AnnotationCollector,
-        mapper: ObjectMapper,
+    fun messageAdapter(
+        objectMapper: ObjectMapper,
         config: MqttProperties,
         client: Mqtt3Client
-    ): Adapter {
-        return Adapter(collector, config, mapper, client)
+    ): MqttMessageAdapter {
+        return MqttMessageAdapter(objectMapper)
+    }
+
+    @Bean
+    fun router(
+        messageAdapter: MqttMessageAdapter,
+        collector: AnnotationCollector,
+        config: MqttProperties,
+        client: Mqtt3Client
+    ): MqttRouter {
+        return MqttRouter(collector, messageAdapter, config, client)
+    }
+
+    @Bean
+    fun publisher(
+        messageAdapter: MqttMessageAdapter,
+        client: Mqtt3Client
+    ): MqttPublisher {
+        return MqttPublisher( messageAdapter, client)
     }
 }

--- a/src/main/kotlin/de/smartsquare/starter/mqtt/MqttAutoConfiguration.kt
+++ b/src/main/kotlin/de/smartsquare/starter/mqtt/MqttAutoConfiguration.kt
@@ -66,11 +66,7 @@ class MqttAutoConfiguration {
     fun jackson(): ObjectMapper = jacksonObjectMapper().findAndRegisterModules()
 
     @Bean
-    fun messageAdapter(
-        objectMapper: ObjectMapper,
-        config: MqttProperties,
-        client: Mqtt3Client
-    ): MqttMessageAdapter {
+    fun messageAdapter(objectMapper: ObjectMapper): MqttMessageAdapter {
         return MqttMessageAdapter(objectMapper)
     }
 
@@ -89,6 +85,6 @@ class MqttAutoConfiguration {
         messageAdapter: MqttMessageAdapter,
         client: Mqtt3Client
     ): MqttPublisher {
-        return MqttPublisher( messageAdapter, client)
+        return MqttPublisher(messageAdapter, client)
     }
 }

--- a/src/main/kotlin/de/smartsquare/starter/mqtt/MqttMessageAdapter.kt
+++ b/src/main/kotlin/de/smartsquare/starter/mqtt/MqttMessageAdapter.kt
@@ -1,0 +1,23 @@
+package de.smartsquare.starter.mqtt
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.hivemq.client.mqtt.datatypes.MqttTopic
+import com.hivemq.client.mqtt.mqtt3.message.publish.Mqtt3Publish
+
+class MqttMessageAdapter(private val jackson: ObjectMapper) {
+
+    fun adapt(message: Mqtt3Publish, targetType: Class<*>): Any {
+        return when {
+            targetType.isAssignableFrom(MqttTopic::class.java) -> message.topic
+            targetType.isAssignableFrom(String::class.java) -> message.payloadAsBytes.decodeToString()
+            else -> jackson.readValue(message.payloadAsBytes, targetType)
+        }
+    }
+
+    fun adapt(payload: Any): ByteArray {
+        return when (payload) {
+            is String -> payload.encodeToByteArray()
+            else -> jackson.writeValueAsString(payload).encodeToByteArray()
+        }
+    }
+}

--- a/src/main/kotlin/de/smartsquare/starter/mqtt/MqttPublisher.kt
+++ b/src/main/kotlin/de/smartsquare/starter/mqtt/MqttPublisher.kt
@@ -1,0 +1,23 @@
+package de.smartsquare.starter.mqtt
+
+import com.hivemq.client.mqtt.datatypes.MqttQos
+import com.hivemq.client.mqtt.mqtt3.Mqtt3Client
+import com.hivemq.client.mqtt.mqtt3.message.publish.Mqtt3Publish
+import org.springframework.stereotype.Component
+import java.util.concurrent.CompletableFuture
+
+@Component
+class MqttPublisher(private val adapter: MqttMessageAdapter, client: Mqtt3Client) {
+
+    private val asyncClient = client.toAsync()
+
+    fun publish(topic: String, qos: MqttQos, payload: Any): CompletableFuture<Mqtt3Publish> {
+        return asyncClient.publish(
+            Mqtt3Publish.builder()
+                .topic(topic)
+                .qos(qos)
+                .payload(adapter.adapt(payload))
+                .build()
+        )
+    }
+}

--- a/src/test/kotlin/de/smartsquare/starter/mqtt/AnnotationCollectorIntegrationTests.kt
+++ b/src/test/kotlin/de/smartsquare/starter/mqtt/AnnotationCollectorIntegrationTests.kt
@@ -11,7 +11,12 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.stereotype.Component
 
-@SpringBootTest(classes = [AnnotationCollectorIntegrationTests.PostProcessorConfiguration::class, AnnotationCollectorIntegrationTests.JacksonConfiguration::class])
+@SpringBootTest(
+    classes = [
+        AnnotationCollectorIntegrationTests.PostProcessorConfiguration::class,
+        AnnotationCollectorIntegrationTests.JacksonConfiguration::class
+    ]
+)
 class AnnotationCollectorIntegrationTests {
 
     @Autowired
@@ -38,8 +43,6 @@ class AnnotationCollectorIntegrationTests {
         @Bean
         fun subscriber() = Subscriber()
     }
-
-    data class TemperatureMessage(val value: Int)
 
     @Component
     class Subscriber {

--- a/src/test/kotlin/de/smartsquare/starter/mqtt/MqttIntegrationTests.kt
+++ b/src/test/kotlin/de/smartsquare/starter/mqtt/MqttIntegrationTests.kt
@@ -78,6 +78,9 @@ class MqttIntegrationTests {
     private lateinit var client: Mqtt3Client
 
     @Autowired
+    private lateinit var publisher: MqttPublisher
+
+    @Autowired
     private lateinit var intSubscriber: IntSubscriber
 
     @Autowired
@@ -132,6 +135,13 @@ class MqttIntegrationTests {
         await untilCallTo { objectSubscriber.receivedPayload } has { value == 3 }
     }
 
+    @Test
+    fun `publishes message`() {
+        publisher.publish("int", MqttQos.EXACTLY_ONCE, 1)
+
+        await untilCallTo { intSubscriber.receivedPayload } has { this == 1 }
+    }
+
     @Component
     class IntSubscriber {
 
@@ -167,6 +177,4 @@ class MqttIntegrationTests {
             _receivedPayload = payload
         }
     }
-
-    data class TemperatureMessage(val value: Int)
 }

--- a/src/test/kotlin/de/smartsquare/starter/mqtt/MqttMessageAdapterTest.kt
+++ b/src/test/kotlin/de/smartsquare/starter/mqtt/MqttMessageAdapterTest.kt
@@ -1,0 +1,74 @@
+package de.smartsquare.starter.mqtt
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.hivemq.client.mqtt.mqtt3.message.publish.Mqtt3Publish
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeInstanceOf
+import org.junit.jupiter.api.Test
+
+class MqttMessageAdapterTest {
+
+    private val adapter = MqttMessageAdapter(jacksonObjectMapper())
+
+    @Test
+    fun `should adapt int message`() {
+        val message = Mqtt3Publish.builder()
+            .topic("test")
+            .payload("1".encodeToByteArray())
+            .build()
+
+        val result = adapter.adapt(message, Int::class.java)
+        result.shouldBeInstanceOf<Int>()
+        result shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `should adapt string message`() {
+        val message = Mqtt3Publish.builder()
+            .topic("test")
+            .payload("1".encodeToByteArray())
+            .build()
+
+        val result = adapter.adapt(message, String::class.java)
+        result.shouldBeInstanceOf<String>()
+        result shouldBeEqualTo "1"
+    }
+
+    @Test
+    fun `should adapt object message`() {
+        val obj = TemperatureMessage(1)
+
+        val message = Mqtt3Publish.builder()
+            .topic("test")
+            .payload(jacksonObjectMapper().writeValueAsBytes(obj))
+            .build()
+
+        val result = adapter.adapt(message, TemperatureMessage::class.java)
+        result.shouldBeInstanceOf<TemperatureMessage>()
+        result shouldBeEqualTo obj
+    }
+
+    @Test
+    fun `should adapt int payload`() {
+        val result = adapter.adapt(1)
+
+        result.decodeToString() shouldBeEqualTo "1"
+    }
+
+    @Test
+    fun `should adapt string payload`() {
+        val result = adapter.adapt("test")
+
+        result.decodeToString() shouldBeEqualTo "test"
+    }
+
+    @Test
+    fun `should adapt object payload`() {
+        val obj = TemperatureMessage(1)
+
+        val result = adapter.adapt(obj)
+
+        // language=json
+        result.decodeToString() shouldBeEqualTo """{"value":1}"""
+    }
+}

--- a/src/test/kotlin/de/smartsquare/starter/mqtt/TemperatureMessage.kt
+++ b/src/test/kotlin/de/smartsquare/starter/mqtt/TemperatureMessage.kt
@@ -1,0 +1,3 @@
+package de.smartsquare.starter.mqtt
+
+data class TemperatureMessage(val value: Int)


### PR DESCRIPTION
This adds a new `MqttPublisher` class and refactors the project a bit:

- Improve names for classes: `Adapter` -> `MqttRouter`.
- Extract actual adapter from `Adapter` and add unit tests.
- Remove duplicate type parameter from the adapter.