### PR TITLE
Mqtt enabled to properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,19 +1,19 @@
 buildscript {
     ext {
         javaVersion = JavaVersion.VERSION_1_8
-        gradleVersion = "7.2"
+        gradleVersion = "7.4.2"
 
-        junitVersion = "5.8.1"
-        kotlinVersion = "1.5.31"
-        detektVersion = "1.18.1"
-        ktlintVersion = "10.2.0"
-        jacksonVersion = "2.13.0"
-        springBootVersion = "2.5.5"
-        awaitilityVersion = "4.1.0"
-        hivemqClientVersion = "1.2.2"
-        testcontainersVersion = "1.16.0"
+        junitVersion = "5.8.2"
+        kotlinVersion = "1.6.21"
+        detektVersion = "1.20.0"
+        ktlintVersion = "10.2.1"
+        jacksonVersion = "2.13.2"
+        springBootVersion = "2.6.7"
+        awaitilityVersion = "4.2.0"
+        hivemqClientVersion = "1.3.0"
+        testcontainersVersion = "1.17.1"
         kluentVersion = "1.68"
-        dokkaVersion = "1.5.31"
+        dokkaVersion = "1.6.21"
         dependencyManagementVersion = "1.0.11.RELEASE"
         gradleNexusVersion = "1.1.0"
         gradleVersionsPluginVersion = "0.39.0"
@@ -90,24 +90,6 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
         jvmTarget = javaVersion.toString()
         allWarningsAsErrors = true
     }
-}
-
-// Make kapt work on recent java versions. Remove when upgrading to Kotlin 1.6.
-// https://youtrack.jetbrains.com/issue/KT-45545
-kotlin {
-    kotlinDaemonJvmArgs = [
-            "-Dfile.encoding=UTF-8",
-            "--add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
-            "--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED",
-            "--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED",
-            "--add-opens=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED",
-            "--add-opens=jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED",
-            "--add-opens=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED",
-            "--add-opens=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED",
-            "--add-opens=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED",
-            "--add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
-            "--add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED"
-    ]
 }
 
 kapt {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/de/smartsquare/starter/mqtt/MqttProperties.kt
+++ b/src/main/kotlin/de/smartsquare/starter/mqtt/MqttProperties.kt
@@ -62,5 +62,10 @@ data class MqttProperties(
      * The mqtt protocol version to use.
      */
     @get:MqttVersion
-    val version: Int = 3
+    val version: Int = 3,
+
+    /**
+     * Disable or enable the mqtt client.
+     */
+    val enabled: Boolean = true
 )

--- a/src/test/kotlin/de/smartsquare/starter/mqtt/EmqxExtension.kt
+++ b/src/test/kotlin/de/smartsquare/starter/mqtt/EmqxExtension.kt
@@ -15,7 +15,7 @@ class EmqxExtension : BeforeAllCallback {
         private val logger = LoggerFactory.getLogger(this::class.java)
         private val logConsumer get() = Slf4jLogConsumer(logger).withSeparateOutputStreams()
 
-        private val emqxImageName = DockerImageName.parse("emqx/emqx:4.3.14")
+        private val emqxImageName = DockerImageName.parse("emqx/emqx:4.4.3")
 
         private val emqx = KGenericContainer(emqxImageName)
             .withEnv("EMQX_LOADED_PLUGINS", "emqx_auth_mnesia")

--- a/src/test/kotlin/de/smartsquare/starter/mqtt/EmqxExtension.kt
+++ b/src/test/kotlin/de/smartsquare/starter/mqtt/EmqxExtension.kt
@@ -15,7 +15,7 @@ class EmqxExtension : BeforeAllCallback {
         private val logger = LoggerFactory.getLogger(this::class.java)
         private val logConsumer get() = Slf4jLogConsumer(logger).withSeparateOutputStreams()
 
-        private val emqxImageName = DockerImageName.parse("emqx/emqx:4.3.8")
+        private val emqxImageName = DockerImageName.parse("emqx/emqx:4.3.14")
 
         private val emqx = KGenericContainer(emqxImageName)
             .withEnv("EMQX_LOADED_PLUGINS", "emqx_auth_mnesia")

--- a/src/test/kotlin/de/smartsquare/starter/mqtt/MqttPropertiesTest.kt
+++ b/src/test/kotlin/de/smartsquare/starter/mqtt/MqttPropertiesTest.kt
@@ -7,6 +7,7 @@ import org.amshove.kluent.shouldNotThrow
 import org.amshove.kluent.shouldStartWith
 import org.amshove.kluent.shouldThrow
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.NoSuchBeanDefinitionException
 import org.springframework.boot.autoconfigure.AutoConfigurations
 import org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration
 import org.springframework.boot.autoconfigure.validation.ValidationAutoConfiguration
@@ -141,6 +142,24 @@ class MqttPropertiesTest {
 
                 rootError.validationErrors.allErrors.size shouldBeEqualTo 1
                 rootError.validationErrors.allErrors[0].defaultMessage shouldStartWith "Invalid mqtt version"
+            }
+    }
+
+    @Test
+    fun `validates mqtt disabled`() {
+        ApplicationContextRunner()
+            .withConfiguration(
+                AutoConfigurations.of(
+                    ConfigurationPropertiesAutoConfiguration::class.java,
+                    ValidationAutoConfiguration::class.java
+                )
+            )
+            .withPropertyValues("mqtt.enabled=false")
+            .withUserConfiguration(TestConfiguration::class.java)
+            .run { context: AssertableApplicationContext ->
+                invoking {
+                    context.getBean(MqttAutoConfiguration::class.java)
+                } shouldThrow NoSuchBeanDefinitionException::class
             }
     }
 }


### PR DESCRIPTION
Provides the enabled property in the MqttProperties.

Question: Is this change necessary? If the MqttProperties bean is not provided this flag is set to false; if the property bean is provided the flag is true. So it somehow might not be necessary.