### PR TITLE
Prepare to rename master branch to main branch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,7 @@ dokkaHtml {
 
             sourceLink {
                 localDirectory.set(file("src/main/kotlin"))
-                remoteUrl.set(new URL("https://github.com/SmartsquareGmbH/mqtt-starter/blob/master/src/main/kotlin"))
+                remoteUrl.set(new URL("https://github.com/SmartsquareGmbH/mqtt-starter/blob/main/src/main/kotlin"))
                 remoteLineSuffix.set("#L")
             }
 


### PR DESCRIPTION
Follow-up to #9 

There is a reference to a directory inside the default branch of this repository in the `build.gradle` which needs to be renamed