### PR TITLE
Fix autoconfig wiring to use new spring boot 3 way

### DIFF
--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=de.smartsquare.starter.mqtt.MqttAutoConfiguration

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+de.smartsquare.starter.mqtt.MqttAutoConfiguration


### PR DESCRIPTION
Spring Boot 3 uses a new file for wiring of AutoConfigurations.