### PR TITLE
Add support for using suspending methods with `@MqttSubscribe`

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ class MqttTimeoutConfigurer : MqttClientConfigurer {
 
 ### Annotation based
 
-The `MqttSubscribe` annotation is scanned on application start and receives messages on the given topic.
+The `MqttSubscribe` annotation is scanned on application start and receives messages on the given topic.  
+It additionally supports kotlin suspend functions. Those functions are run inside the mqtt client thread pool.
 
 ```kotlin
 import com.hivemq.client.mqtt.datatypes.MqttQos.AT_LEAST_ONCE
@@ -107,6 +108,12 @@ class TestConsumer {
     fun subscribe() {
         println("Something happened")
     }
+
+  // No parameters
+  @MqttSubscribe(topic = "/home/ping", qos = AT_LEAST_ONCE)
+  suspend fun suspending() {
+    println("Something happened suspending")
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ class TestConsumer {
         println("Something happened")
     }
 
-  // No parameters
+  // Suspending function
   @MqttSubscribe(topic = "/home/ping", qos = AT_LEAST_ONCE)
   suspend fun suspending() {
     println("Something happened suspending")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,8 @@ repositories {
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
 
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core")
+
     implementation(platform("org.springframework.boot:spring-boot-dependencies:3.2.3"))
     implementation("org.springframework.boot:spring-boot")
     implementation("org.springframework.boot:spring-boot-autoconfigure")

--- a/src/main/kotlin/de/smartsquare/starter/mqtt/MqttClientConfigurer.kt
+++ b/src/main/kotlin/de/smartsquare/starter/mqtt/MqttClientConfigurer.kt
@@ -7,7 +7,7 @@ import com.hivemq.client.mqtt.mqtt5.Mqtt5ClientBuilder
  * Interface to enable more advanced configuration for the [Mqtt3ClientBuilder] than what is possible with the
  * properties.
  */
-interface Mqtt3ClientConfigurer {
+fun interface Mqtt3ClientConfigurer {
 
     /**
      * To be implemented by consumers. Can perform any configuration on the given [builder] in place.
@@ -20,7 +20,7 @@ interface Mqtt3ClientConfigurer {
  * Interface to enable more advanced configuration for the [Mqtt5ClientBuilder] than what is possible with the
  * properties.
  */
-interface Mqtt5ClientConfigurer {
+fun interface Mqtt5ClientConfigurer {
 
     /**
      * To be implemented by consumers. Can perform any configuration on the given [builder] in place.

--- a/src/main/kotlin/de/smartsquare/starter/mqtt/MqttHandler.kt
+++ b/src/main/kotlin/de/smartsquare/starter/mqtt/MqttHandler.kt
@@ -47,27 +47,26 @@ class MqttHandler(
         try {
             subscriber.invoke(*Array(parameterTypes.size) { adapter.adapt(message, parameterTypes[it]) })
         } catch (e: JsonMappingException) {
-            throw MqttMessageException(
-                topic,
-                message.payload,
-                "Error while handling mqtt message on topic [$topic]: Failed to map payload to target class",
-                e,
-            )
-        } catch (e: JacksonException) {
-            throw MqttMessageException(
-                topic,
-                message.payload,
-                "Error while handling mqtt message on topic [$topic]: Failed to parse payload",
-                e,
-            )
-        } catch (e: Exception) {
             messageErrorHandler.handle(
                 MqttMessageException(
                     topic,
                     payload,
-                    "Error while handling mqtt message on topic [$topic]",
+                    "Error while handling mqtt message on topic [$topic]: Failed to map payload to target class",
                     e,
                 ),
+            )
+        } catch (e: JacksonException) {
+            messageErrorHandler.handle(
+                MqttMessageException(
+                    topic,
+                    payload,
+                    "Error while handling mqtt message on topic [$topic]: Failed to parse payload",
+                    e,
+                ),
+            )
+        } catch (e: Exception) {
+            messageErrorHandler.handle(
+                MqttMessageException(topic, payload, "Error while handling mqtt message on topic [$topic]", e),
             )
         }
     }

--- a/src/main/kotlin/de/smartsquare/starter/mqtt/MqttHandler.kt
+++ b/src/main/kotlin/de/smartsquare/starter/mqtt/MqttHandler.kt
@@ -3,10 +3,15 @@ package de.smartsquare.starter.mqtt
 import com.fasterxml.jackson.core.JacksonException
 import com.fasterxml.jackson.databind.JsonMappingException
 import com.hivemq.client.mqtt.datatypes.MqttTopic
-import de.smartsquare.starter.mqtt.MqttSubscriberCollector.ResolvedMqttSubscriber
+import de.smartsquare.starter.mqtt.MqttHandler.AnnotatedMethodDelegate
+import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
-import java.lang.reflect.InvocationTargetException
+import java.lang.invoke.MethodHandles
 import java.util.concurrent.ConcurrentHashMap
+import kotlin.reflect.full.callSuspend
+import kotlin.reflect.full.valueParameters
+import kotlin.reflect.jvm.jvmErasure
+import kotlin.reflect.jvm.kotlinFunction
 
 /**
  * Class for consuming and forwarding messages to the correct subscriber.
@@ -18,57 +23,76 @@ class MqttHandler(
 ) {
 
     private val logger = LoggerFactory.getLogger(this::class.java)
+    private val subscriberCache = ConcurrentHashMap<MqttTopic, MqttSubscriber>(collector.subscribers.size)
+    private val lookup = MethodHandles.publicLookup()
 
-    private val subscriberCache = ConcurrentHashMap<MqttTopic, ResolvedMqttSubscriber>(collector.subscribers.size)
+    private data class MqttSubscriber(val subscriber: AnnotatedMethodDelegate, val parameterTypes: List<Class<*>>)
+
+    private fun interface AnnotatedMethodDelegate {
+        fun invoke(vararg args: Any)
+    }
 
     /**
      * Handles a single [message]. The topic of the message is used to determine the correct subscriber which is then
      * invoked with parameters produced by the [MqttMessageAdapter].
      */
     fun handle(message: MqttPublishContainer) {
-        val topic = message.topic
+        val (topic, payload) = message
+        if (logger.isTraceEnabled) logger.trace("Received mqtt message on topic [$topic] with payload $payload")
+        val (subscriber, parameterTypes) = getSubscriber(topic)
+        val adaptedParameterResult = adaptParameters(parameterTypes, message, topic)
 
-        if (logger.isTraceEnabled) {
-            logger.trace("Received mqtt message on topic [$topic] with payload ${message.payload}")
-        }
+        adaptedParameterResult
+            .mapCatching { args -> subscriber.invoke(*args) }
+            .onFailure { t ->
+                val mqttMessageException = t as? MqttMessageException
+                    ?: MqttMessageException(topic, payload, "Error while handling mqtt message on topic [$topic]", t)
 
-        val subscriber = subscriberCache
-            .getOrPut(topic) { collector.subscribers.find { it.topic.matches(topic) } }
+                messageErrorHandler.handle(mqttMessageException)
+            }
+    }
+
+    /**
+     * Returns the subscriber for the given [topic].
+     * If no subscriber is found, an error is thrown.
+     * The subscriber is cached for performance reasons.
+     *
+     * If the function is a suspend function, it is wrapped in a suspend call. For normal functions, a method handle is
+     * created and cached.
+     */
+    private fun getSubscriber(topic: MqttTopic): MqttSubscriber = subscriberCache.getOrPut(topic) {
+        val subscriber = collector.subscribers.find { it.topic.matches(topic) }
             ?: error("No subscriber found for topic $topic")
-
-        try {
-            val parameters = subscriber.method.parameterTypes
-                .map { adapter.adapt(message, it) }
-                .toTypedArray()
-
-            subscriber.method.invoke(subscriber.bean, *parameters)
-        } catch (e: InvocationTargetException) {
-            messageErrorHandler.handle(
-                MqttMessageException(
-                    topic,
-                    message.payload,
-                    "Error while handling mqtt message on topic [$topic]",
-                    e,
-                ),
-            )
-        } catch (e: JsonMappingException) {
-            messageErrorHandler.handle(
-                MqttMessageException(
-                    topic,
-                    message.payload,
-                    "Error while handling mqtt message on topic [$topic]: Failed to map payload to target class",
-                    e,
-                ),
-            )
-        } catch (e: JacksonException) {
-            messageErrorHandler.handle(
-                MqttMessageException(
-                    topic,
-                    message.payload,
-                    "Error while handling mqtt message on topic [$topic]: Failed to parse payload",
-                    e,
-                ),
-            )
+        val kFunction = subscriber.method.kotlinFunction
+        val parameterTypes = kFunction?.valueParameters?.map { it.type.jvmErasure.java }
+            ?: subscriber.method.parameterTypes.toList()
+        val delegate = if (kFunction?.isSuspend == true) {
+            AnnotatedMethodDelegate { args -> runBlocking { kFunction.callSuspend(subscriber.bean, *args) } }
+        } else {
+            val handle = lookup.unreflect(subscriber.method)
+            AnnotatedMethodDelegate { args -> handle.invokeWithArguments(subscriber.bean, *args) }
         }
+
+        MqttSubscriber(delegate, parameterTypes)
+    }
+
+    /**
+     * Adapts the payload of the [message] to the [parameterTypes] of the subscriber.
+     * If an error occurs, the error is logged and the [MqttMessageErrorHandler] is called.
+     */
+    private fun adaptParameters(
+        parameterTypes: List<Class<*>>,
+        message: MqttPublishContainer,
+        topic: MqttTopic,
+    ): Result<Array<Any>> {
+        val (e, errorMessage) = try {
+            return Result.success(parameterTypes.map { adapter.adapt(message, it) }.toTypedArray())
+        } catch (e: JsonMappingException) {
+            e to "Error while handling mqtt message on topic [$topic]: Failed to map payload to target class"
+        } catch (e: JacksonException) {
+            e to "Error while handling mqtt message on topic [$topic]: Failed to parse payload"
+        }
+
+        return Result.failure(MqttMessageException(topic, message.payload, errorMessage, e))
     }
 }

--- a/src/main/kotlin/de/smartsquare/starter/mqtt/MqttPublishContainer.kt
+++ b/src/main/kotlin/de/smartsquare/starter/mqtt/MqttPublishContainer.kt
@@ -9,8 +9,16 @@ import com.hivemq.client.mqtt.mqtt5.message.publish.Mqtt5Publish
  */
 sealed interface MqttPublishContainer {
     val topic: MqttTopic
+
     val payload: ByteArray
+
     val value: Any
+
+    @JvmSynthetic
+    operator fun component1(): MqttTopic = topic
+
+    @JvmSynthetic
+    operator fun component2(): ByteArray = payload
 }
 
 /**

--- a/src/test/kotlin/de/smartsquare/starter/mqtt/Mqtt5AutoConfigurationTest.kt
+++ b/src/test/kotlin/de/smartsquare/starter/mqtt/Mqtt5AutoConfigurationTest.kt
@@ -6,6 +6,7 @@ import com.hivemq.client.mqtt.mqtt5.message.publish.Mqtt5Publish
 import de.smartsquare.starter.mqtt.Mqtt5AutoConfigurationTest.ErrorSubscriber
 import de.smartsquare.starter.mqtt.Mqtt5AutoConfigurationTest.IntSubscriber
 import de.smartsquare.starter.mqtt.Mqtt5AutoConfigurationTest.PublishSubscriber
+import de.smartsquare.starter.mqtt.Mqtt5AutoConfigurationTest.SuspendSubscriber
 import org.amshove.kluent.shouldBeEqualTo
 import org.awaitility.kotlin.await
 import org.junit.jupiter.api.Test
@@ -21,6 +22,7 @@ import org.springframework.test.context.TestPropertySource
         MqttAutoConfiguration::class,
         IntSubscriber::class,
         PublishSubscriber::class,
+        SuspendSubscriber::class,
         ErrorSubscriber::class,
     ],
 )
@@ -38,6 +40,9 @@ class Mqtt5AutoConfigurationTest {
 
     @Autowired
     private lateinit var publishSubscriber: PublishSubscriber
+
+    @Autowired
+    private lateinit var suspendSubscriber: SuspendSubscriber
 
     @Autowired
     private lateinit var errorSubscriber: ErrorSubscriber
@@ -68,6 +73,20 @@ class Mqtt5AutoConfigurationTest {
 
         await untilAssertedKluent {
             publishSubscriber.receivedPayload shouldBeEqualTo publish
+        }
+    }
+
+    @Test
+    fun `receives publish message from suspend function`() {
+        val publish = Mqtt5Publish.builder()
+            .topic("suspend")
+            .payload("test".toByteArray())
+            .qos(MqttQos.EXACTLY_ONCE).build()
+
+        client.toBlocking().publish(publish)
+
+        await untilAssertedKluent {
+            suspendSubscriber.receivedPayload shouldBeEqualTo publish
         }
     }
 
@@ -123,6 +142,18 @@ class Mqtt5AutoConfigurationTest {
 
         @MqttSubscribe(topic = "string", qos = MqttQos.EXACTLY_ONCE)
         fun onMessage(payload: Mqtt5Publish) {
+            _receivedPayload = payload
+        }
+    }
+
+    @Component
+    class SuspendSubscriber {
+
+        val receivedPayload get() = _receivedPayload
+        private var _receivedPayload: Mqtt5Publish? = null
+
+        @MqttSubscribe(topic = "suspend", qos = MqttQos.EXACTLY_ONCE)
+        suspend fun onMessage(payload: Mqtt5Publish) {
             _receivedPayload = payload
         }
     }

--- a/src/test/kotlin/de/smartsquare/starter/mqtt/MqttHandlerTest.kt
+++ b/src/test/kotlin/de/smartsquare/starter/mqtt/MqttHandlerTest.kt
@@ -1,0 +1,214 @@
+package de.smartsquare.starter.mqtt
+
+import com.fasterxml.jackson.module.kotlin.jsonMapper
+import com.hivemq.client.mqtt.datatypes.MqttQos
+import com.hivemq.client.mqtt.mqtt5.message.publish.Mqtt5Publish
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+object TestMqttSubscriberCollector {
+    operator fun invoke(bean: Any): MqttSubscriberCollector = MqttSubscriberCollector(MqttProperties()).apply {
+        postProcessAfterInitialization(bean, "testBean")
+    }
+}
+
+@Suppress("RedundantSuspendModifier")
+class MqttHandlerTest {
+
+    private val mapper = jsonMapper { findAndAddModules() }
+    private val adapter = DefaultMqttMessageAdapter(mapper)
+    private val messageErrorHandler = MqttMessageErrorHandler()
+
+    @Test
+    fun `invoke correct method for multiple subsciber methods`() {
+        val subscriber = object {
+            var invoked = false
+
+            @MqttSubscribe("test", qos = MqttQos.EXACTLY_ONCE)
+            fun test() {
+                invoked = true
+            }
+
+            @MqttSubscribe("test2", qos = MqttQos.EXACTLY_ONCE)
+            fun test2() = Unit
+        }
+
+        val collector = TestMqttSubscriberCollector(subscriber)
+        collector.subscribers.size shouldBeEqualTo 2
+        val handler = MqttHandler(collector, adapter, messageErrorHandler)
+
+        val publish = Mqtt5Publish.builder().topic("test").payload("1".encodeToByteArray()).build()
+        handler.handle(Mqtt5PublishContainer(publish))
+
+        subscriber.invoked shouldBeEqualTo true
+    }
+
+    @Nested
+    inner class RegularMethodInvocation {
+        @Test
+        fun `invokes parameterless subscriber method`() {
+            val subscriber = object {
+                var invoked = false
+
+                @MqttSubscribe("test", qos = MqttQos.EXACTLY_ONCE)
+                fun test() {
+                    invoked = true
+                }
+            }
+
+            val collector = TestMqttSubscriberCollector(subscriber)
+            val handler = MqttHandler(collector, adapter, messageErrorHandler)
+
+            val publish = Mqtt5Publish.builder().topic("test").payload("1".encodeToByteArray()).build()
+            handler.handle(Mqtt5PublishContainer(publish))
+
+            subscriber.invoked shouldBeEqualTo true
+        }
+
+        @Test
+        fun `invokes string subscriber method`() {
+            val subscriber = object {
+                lateinit var invoked: String
+
+                @MqttSubscribe("test", qos = MqttQos.EXACTLY_ONCE)
+                fun test(data: String) {
+                    invoked = data
+                }
+            }
+
+            val collector = TestMqttSubscriberCollector(subscriber)
+            val handler = MqttHandler(collector, adapter, messageErrorHandler)
+
+            val publish = Mqtt5Publish.builder().topic("test").payload("1".encodeToByteArray()).build()
+            handler.handle(Mqtt5PublishContainer(publish))
+
+            subscriber.invoked shouldBeEqualTo "1"
+        }
+
+        @Test
+        fun `invokes byte subscriber method`() {
+            val subscriber = object {
+                lateinit var invoked: ByteArray
+
+                @MqttSubscribe("test", qos = MqttQos.EXACTLY_ONCE)
+                fun test(data: ByteArray) {
+                    invoked = data
+                }
+            }
+
+            val collector = TestMqttSubscriberCollector(subscriber)
+            val handler = MqttHandler(collector, adapter, messageErrorHandler)
+
+            val publish = Mqtt5Publish.builder().topic("test").payload("1".encodeToByteArray()).build()
+            handler.handle(Mqtt5PublishContainer(publish))
+
+            subscriber.invoked shouldBeEqualTo "1".encodeToByteArray()
+        }
+
+        @Test
+        fun `invokes object subscriber method`() {
+            val subscriber = object {
+                lateinit var invoked: TemperatureMessage
+
+                @MqttSubscribe("test", qos = MqttQos.EXACTLY_ONCE)
+                fun test(data: TemperatureMessage) {
+                    invoked = data
+                }
+            }
+
+            val collector = TestMqttSubscriberCollector(subscriber)
+            val handler = MqttHandler(collector, adapter, messageErrorHandler)
+
+            val obj = TemperatureMessage(1)
+            val publish = Mqtt5Publish.builder().topic("test").payload(mapper.writeValueAsBytes(obj)).build()
+            handler.handle(Mqtt5PublishContainer(publish))
+
+            subscriber.invoked shouldBeEqualTo obj
+        }
+    }
+
+    @Nested
+    inner class SuspendingMethodInvocation {
+        @Test
+        fun `invokes suspend subscriber method`() {
+            val subscriber = object {
+                var invoked = false
+
+                @MqttSubscribe("test", qos = MqttQos.EXACTLY_ONCE)
+                suspend fun test() {
+                    invoked = true
+                }
+            }
+
+            val collector = TestMqttSubscriberCollector(subscriber)
+            val handler = MqttHandler(collector, adapter, messageErrorHandler)
+
+            val publish = Mqtt5Publish.builder().topic("test").payload("1".encodeToByteArray()).build()
+            handler.handle(Mqtt5PublishContainer(publish))
+
+            subscriber.invoked shouldBeEqualTo true
+        }
+
+        @Test
+        fun `invokes suspend string subscriber method`() {
+            val subscriber = object {
+                lateinit var invoked: String
+
+                @MqttSubscribe("test", qos = MqttQos.EXACTLY_ONCE)
+                suspend fun test(data: String) {
+                    invoked = data
+                }
+            }
+
+            val collector = TestMqttSubscriberCollector(subscriber)
+            val handler = MqttHandler(collector, adapter, messageErrorHandler)
+
+            val publish = Mqtt5Publish.builder().topic("test").payload("1".encodeToByteArray()).build()
+            handler.handle(Mqtt5PublishContainer(publish))
+
+            subscriber.invoked shouldBeEqualTo "1"
+        }
+
+        @Test
+        fun `invokes suspend byte subscriber method`() {
+            val subscriber = object {
+                lateinit var invoked: ByteArray
+
+                @MqttSubscribe("test", qos = MqttQos.EXACTLY_ONCE)
+                suspend fun test(data: ByteArray) {
+                    invoked = data
+                }
+            }
+
+            val collector = TestMqttSubscriberCollector(subscriber)
+            val handler = MqttHandler(collector, adapter, messageErrorHandler)
+
+            val publish = Mqtt5Publish.builder().topic("test").payload("1".encodeToByteArray()).build()
+            handler.handle(Mqtt5PublishContainer(publish))
+
+            subscriber.invoked shouldBeEqualTo "1".encodeToByteArray()
+        }
+
+        @Test
+        fun `invokes suspend object subscriber method`() {
+            val subscriber = object {
+                lateinit var invoked: TemperatureMessage
+
+                @MqttSubscribe("test", qos = MqttQos.EXACTLY_ONCE)
+                suspend fun test(data: TemperatureMessage) {
+                    invoked = data
+                }
+            }
+
+            val collector = TestMqttSubscriberCollector(subscriber)
+            val handler = MqttHandler(collector, adapter, messageErrorHandler)
+
+            val obj = TemperatureMessage(1)
+            val publish = Mqtt5Publish.builder().topic("test").payload(mapper.writeValueAsBytes(obj)).build()
+            handler.handle(Mqtt5PublishContainer(publish))
+
+            subscriber.invoked shouldBeEqualTo obj
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds support for suspending methods in the MqttSubscriberCollector and MqttHandler.  
This allows for suspending methods to be used as subscriber methods.
For instance:

```kotlin
@MqttSubscribe("test", qos = MqttQos.EXACTLY_ONCE)
suspend fun test(payload: String) {
    ...
}
```

For the existing calling mechanism based on `Method`, I changed it to use [`MethodHandle`](https://jornvernee.github.io/methodhandles/2024/01/19/methodhandle-primer.html).  
I also added some tests for invoking the handler.