### PR TITLE
Fix "messageExpiryInterval" check failure in MQTT 5 publish

### DIFF
--- a/src/main/kotlin/de/smartsquare/starter/mqtt/MqttPublisher.kt
+++ b/src/main/kotlin/de/smartsquare/starter/mqtt/MqttPublisher.kt
@@ -117,12 +117,16 @@ class Mqtt5Publisher(private val adapter: MqttMessageAdapter, client: Mqtt5Clien
 
         if (options != null) {
             build.retain(options.retain)
-                .messageExpiryInterval(options.messageExpiryInterval)
                 .payloadFormatIndicator(options.payloadFormatIndicator)
                 .contentType(options.contentType)
                 .responseTopic(options.responseTopic)
                 .correlationData(options.correlationData)
                 .userProperties(options.userProperties)
+            if (options.messageExpiryInterval == MqttPublish.NO_MESSAGE_EXPIRY) {
+                build.noMessageExpiry()
+            } else {
+                build.messageExpiryInterval(options.messageExpiryInterval)
+            }
         }
 
         return asyncClient.publish(build.build())


### PR DESCRIPTION
`Mqtt5PublishBuilder` will check `messageExpiryInterval` parameter in its builder method, which results in assertion failure if `PublishingOptions.messageExpiryInterval` is left unspecified or maintained at its default setting.
Using `Mqtt5PublishBuilder#noMessageExpiry()` to explicitly denote "no message expiry" when retaining the default `messageExpiryInterval`.
This fixes #18.
The upstream have introduced a special value `-1` to disable message expiry in `Mqtt5PublishBuilder.messageExpiryInterval`, but haven't released so far.
References: hivemq/hivemq-mqtt-client#580, hivemq/hivemq-mqtt-client#604.